### PR TITLE
Added message/service dependencies for nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,11 +56,13 @@ target_link_libraries(o3d3xx_node
   ${catkin_LIBRARIES}
   ${libo3d3xx_LIBRARIES}
   )
+add_dependencies(o3d3xx_node ${PROJECT_NAME}_generate_messages_cpp)
 
 add_executable(o3d3xx_config_node src/o3d3xx_config_node.cpp)
 target_link_libraries(o3d3xx_config_node
   ${catkin_LIBRARIES}
   )
+add_dependencies(o3d3xx_config_node ${PROJECT_NAME}_generate_messages_cpp)
 
 add_executable(o3d3xx_file_writer_node src/o3d3xx_file_writer_node.cpp)
 target_link_libraries(o3d3xx_file_writer_node


### PR DESCRIPTION
Message/service dependencies must be specified in `CMakeLists.txt` to ensure that they are generated *before* executables and libraries are built.  More information can be found [here](http://wiki.ros.org/catkin/CMakeLists.txt#Important_Prerequisites.2BAC8-Constraints).

This issue may not occur on multi-core machines, where messages are generated in parallel before they are needed.  This issue can be reproduced on such systems by compiling with only a single thread: `catkin_make -j1`