### PR TITLE
Require the Dump service is generated before o3d3xx_file_writer_node …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries(o3d3xx_file_writer_node
   ${catkin_LIBRARIES}
   ${Boost_FILESYSTEM_LIBRARY}
   )
+add_dependencies(o3d3xx_file_writer_node ${PROJECT_NAME}_generate_messages_cpp)
 
 #############
 ## Install ##


### PR DESCRIPTION
…to fix intermittent fatal error: 'o3d3xx/Dump.h: No such file or directory'