### PR TITLE
Updating CmakeLists.txt to use RPATH so the ROS Node can find libo3d3…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ generate_messages(
   std_msgs
   )
 
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 ###################################
 ## catkin specific configuration ##
 ###################################


### PR DESCRIPTION
…xx in the default install location /opt/ without modifying LD_LIBRARY_PATH

Depends on this Pull Request:
https://github.com/lovepark/libo3d3xx/pull/21

```
catkin_make install
ldd $(find ~/catkin_ws/install -name o3d3xx_node) | grep o3d3xx
	libo3d3xx.so.0.2.0 => /opt/libo3d3xx/lib/libo3d3xx.so.0.2.0 (0x00007fd9ab3de000)
```