### PR TITLE
Allow frame_id to be configurable. Modify the topic names to use rela…

### DIFF
--- a/launch/camera.launch
+++ b/launch/camera.launch
@@ -10,49 +10,56 @@
   <arg name="timeout_millis" default="500"/>
   <arg name="timeout_tolerance_secs" default="5.0"/>
   <arg name="publish_viz_images" default="true"/>
+  <arg name="frame_id_base" default="$(arg ns)/$(arg nn)" />
   <arg name="respawn" default="false"/>
 
-  <node pkg="o3d3xx"
-	type="o3d3xx_node"
-	ns="$(arg ns)"
-	name="$(arg nn)"
-	output="screen"
-	respawn="$(arg respawn)">
+  <!-- TODO: Consider removing the group tag and let the includer determine the
+      namespace using a group. -->
+  <group ns="$(arg ns)">
+    <node pkg="o3d3xx"
+        type="o3d3xx_node"
+        name="$(arg nn)"
+        output="screen"
+        respawn="$(arg respawn)">
 
-    <param name="ip" value="$(arg ip)"/>
-    <param name="xmlrpc_port" value="$(arg xmlrpc_port)"/>
-    <param name="password" value="$(arg password)"/>
-    <param name="schema_mask" value="$(arg schema_mask)"/>
-    <param name="timeout_millis" value="$(arg timeout_millis)"/>
-    <param name="timeout_tolerance_secs"
-           value="$(arg timeout_tolerance_secs)"/>
-    <param name="publish_viz_images" value="$(arg publish_viz_images)"/>
+      <param name="ip" value="$(arg ip)"/>
+      <param name="xmlrpc_port" value="$(arg xmlrpc_port)"/>
+      <param name="password" value="$(arg password)"/>
+      <param name="schema_mask" value="$(arg schema_mask)"/>
+      <param name="timeout_millis" value="$(arg timeout_millis)"/>
+      <param name="timeout_tolerance_secs"
+             value="$(arg timeout_tolerance_secs)"/>
+      <param name="publish_viz_images" value="$(arg publish_viz_images)"/>
+      <param name="frame_id_base" value="$(arg frame_id_base)" />
 
-    <!-- published topics -->
-    <remap from="/cloud" to="/$(arg ns)/$(arg nn)/cloud"/>
-    <remap from="/depth" to="/$(arg ns)/$(arg nn)/depth"/>
-    <remap from="/depth_viz" to="/$(arg ns)/$(arg nn)/depth_viz"/>
-    <remap from="/amplitude" to="/$(arg ns)/$(arg nn)/amplitude"/>
-    <remap from="/raw_amplitude" to="/$(arg ns)/$(arg nn)/raw_amplitude"/>
-    <remap from="/confidence" to="/$(arg ns)/$(arg nn)/confidence"/>
-    <remap from="/unit_vectors" to="/$(arg ns)/$(arg nn)/unit_vectors"/>
-    <remap from="/good_bad_pixels" to="/$(arg ns)/$(arg nn)/good_bad_pixels"/>
-    <remap from="/xyz_image" to="/$(arg ns)/$(arg nn)/xyz_image"/>
-    <remap from="/extrinsics" to="/$(arg ns)/$(arg nn)/extrinsics"/>
+      <!-- TODO: Consider removing $(arg nn) from your topics to keep them
+          shorter, give the includer more flexibility, and all of these remaps
+          dissapear. -->
+      <!-- published topics -->
+      <remap from="cloud" to="$(arg nn)/cloud"/>
+      <remap from="depth" to="$(arg nn)/depth"/>
+      <remap from="depth_viz" to="$(arg nn)/depth_viz"/>
+      <remap from="amplitude" to="$(arg nn)/amplitude"/>
+      <remap from="raw_amplitude" to="$(arg nn)/raw_amplitude"/>
+      <remap from="confidence" to="$(arg nn)/confidence"/>
+      <remap from="unit_vectors" to="$(arg nn)/unit_vectors"/>
+      <remap from="good_bad_pixels" to="$(arg nn)/good_bad_pixels"/>
+      <remap from="xyz_image" to="$(arg nn)/xyz_image"/>
+      <remap from="extrinsics" to="$(arg nn)/extrinsics"/>
 
-    <!-- advertised services -->
-    <remap from="/GetVersion" to="/$(arg ns)/$(arg nn)/GetVersion"/>
-    <remap from="/Dump" to="/$(arg ns)/$(arg nn)/Dump"/>
-    <remap from="/Config" to="/$(arg ns)/$(arg nn)/Config"/>
-    <remap from="/Rm" to="/$(arg ns)/$(arg nn)/Rm"/>
+      <!-- advertised services -->
+      <remap from="GetVersion" to="$(arg nn)/GetVersion"/>
+      <remap from="Dump" to="$(arg nn)/Dump"/>
+      <remap from="Config" to="$(arg nn)/Config"/>
+      <remap from="Rm" to="$(arg nn)/Rm"/>
 
-  </node>
+    </node>
 
-  <node pkg="tf2_ros"
-	type="static_transform_publisher"
-	ns="$(arg ns)"
-	name="$(arg nn)_tf"
-	args="0 0 0 -1.5707963267948966 0 -1.5707963267948966 $(arg ns)/$(arg nn)_link $(arg ns)/$(arg nn)_optical_link"
-	respawn="$(arg respawn)" />
+    <node pkg="tf2_ros"
+        type="static_transform_publisher"
+        name="$(arg nn)_tf"
+        args="0 0 0 -1.5707963267948966 0 -1.5707963267948966 $(arg frame_id_base)_link $(arg frame_id_base)_optical_link"
+        respawn="$(arg respawn)" />
+  </group>
 
 </launch>

--- a/launch/config.launch
+++ b/launch/config.launch
@@ -5,15 +5,17 @@
   <arg name="nn" default="camera"/>
   <arg name="infile" default="-"/>
 
-  <node pkg="o3d3xx"
-	type="o3d3xx_config_node"
-	ns="$(arg ns)/$(arg nn)"
-	name="config_node"
-	output="screen">
+  <!-- TODO: Consider removing the group and let the includer determine the
+      namespace using a group. -->
+  <group ns="$(arg ns)/$(arg nn)">
+    <node pkg="o3d3xx"
+    type="o3d3xx_config_node"
+    name="config_node"
+    output="screen">
 
-    <param name="infile" value="$(arg infile)"/>
-    <remap from="/Config" to="/$(arg ns)/$(arg nn)/Config"/>
+      <param name="infile" value="$(arg infile)"/>
 
-  </node>
+    </node>
+  </group>
 
 </launch>

--- a/launch/file_writer.launch
+++ b/launch/file_writer.launch
@@ -7,37 +7,27 @@
   <arg name="dump_yaml" default="false"/>
   <arg name="topic_suffix" default=""/>
 
-  <node pkg="o3d3xx"
-	type="o3d3xx_file_writer_node"
-	ns="$(arg ns)/$(arg nn)"
-	name="file_writer"
-	output="screen">
+  <group ns="$(arg ns)/$(arg nn)">
+    <node pkg="o3d3xx"
+        type="o3d3xx_file_writer_node"
+        name="file_writer"
+        output="screen">
 
-    <param name="outdir" value="$(arg outdir)"/>
-    <param name="dump_yaml" value="$(arg dump_yaml)"/>
+      <param name="outdir" value="$(arg outdir)"/>
+      <param name="dump_yaml" value="$(arg dump_yaml)"/>
 
-    <!-- subscribed topics -->
-    <remap from="/cloud"
-	   to="/$(arg ns)/$(arg nn)/cloud$(arg topic_suffix)"/>
+      <!-- subscribed topics -->
+      <remap from="cloud" to="cloud$(arg topic_suffix)"/>
+      <remap from="depth" to="depth$(arg topic_suffix)"/>
+      <remap from="amplitude" to="amplitude$(arg topic_suffix)"/>
+      <remap from="raw_amplitude" to="raw_amplitude$(arg topic_suffix)"/>
+      <remap from="confidence" to="confidence$(arg topic_suffix)"/>
+      <remap from="xyz_image" to="xyz_image$(arg topic_suffix)"/>
 
-    <remap from="/depth"
-	   to="/$(arg ns)/$(arg nn)/depth$(arg topic_suffix)"/>
+      <!-- services we call -->
+      <remap from="Dump" to="Dump"/>
 
-    <remap from="/amplitude"
-	   to="/$(arg ns)/$(arg nn)/amplitude$(arg topic_suffix)"/>
-
-    <remap from="/raw_amplitude"
-	   to="/$(arg ns)/$(arg nn)/raw_amplitude$(arg topic_suffix)"/>
-
-    <remap from="/confidence"
-	   to="/$(arg ns)/$(arg nn)/confidence$(arg topic_suffix)"/>
-
-    <remap from="/xyz_image"
-           to="/$(arg ns)/$(arg nn)/xyz_image$(arg topic_suffix)"/>
-
-    <!-- services we call -->
-    <remap from="/Dump" to="/$(arg ns)/$(arg nn)/Dump"/>
-
-  </node>
+    </node>
+  </group>
 
 </launch>

--- a/launch/throttled.launch
+++ b/launch/throttled.launch
@@ -5,40 +5,36 @@
   <arg name="nn" default="camera"/>
   <arg name="hz" default="1.0"/>
 
-  <node pkg="topic_tools"
-	type="throttle"
-	ns="$(arg ns)/$(arg nn)"
-	name="cloud_throttler"
-	args="messages /$(arg ns)/$(arg nn)/cloud $(arg hz)"/>
-
-  <node pkg="topic_tools"
-	type="throttle"
-	ns="$(arg ns)/$(arg nn)"
-	name="depth_throttler"
-	args="messages /$(arg ns)/$(arg nn)/depth $(arg hz)"/>
-
-  <node pkg="topic_tools"
-	type="throttle"
-	ns="$(arg ns)/$(arg nn)"
-	name="amplitude_throttler"
-	args="messages /$(arg ns)/$(arg nn)/amplitude $(arg hz)"/>
-
-  <node pkg="topic_tools"
-	type="throttle"
-	ns="$(arg ns)/$(arg nn)"
-	name="raw_amplitude_throttler"
-	args="messages /$(arg ns)/$(arg nn)/raw_amplitude $(arg hz)"/>
-
-  <node pkg="topic_tools"
-	type="throttle"
-	ns="$(arg ns)/$(arg nn)"
-	name="confidence_throttler"
-	args="messages /$(arg ns)/$(arg nn)/confidence $(arg hz)"/>
-
-  <node pkg="topic_tools"
+  <group ns="$(arg ns)/$(arg nn)">
+    <node pkg="topic_tools"
         type="throttle"
-        ns="$(arg ns)/$(arg nn)"
+        name="cloud_throttler"
+        args="messages $(arg ns)/$(arg nn)/cloud $(arg hz)"/>
+
+    <node pkg="topic_tools"
+        type="throttle"
+        name="depth_throttler"
+        args="messages $(arg ns)/$(arg nn)/depth $(arg hz)"/>
+
+    <node pkg="topic_tools"
+        type="throttle"
+        name="amplitude_throttler"
+        args="messages $(arg ns)/$(arg nn)/amplitude $(arg hz)"/>
+
+    <node pkg="topic_tools"
+        type="throttle"
+        name="raw_amplitude_throttler"
+        args="messages $(arg ns)/$(arg nn)/raw_amplitude $(arg hz)"/>
+
+    <node pkg="topic_tools"
+        type="throttle"
+        name="confidence_throttler"
+        args="messages $(arg ns)/$(arg nn)/confidence $(arg hz)"/>
+
+    <node pkg="topic_tools"
+        type="throttle"
         name="xyz_image_throttler"
-        args="messages /$(arg ns)/$(arg nn)/xyz_image $(arg hz)"/>
+        args="messages $(arg ns)/$(arg nn)/xyz_image $(arg hz)"/>
+  </group>
 
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package>
 
   <name>o3d3xx</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>O3D3xx ToF Camera ROS package</description>
   <maintainer email="tom@loveparkrobotics.com">Tom Panzarella</maintainer>
   <license>Apache 2</license>

--- a/src/o3d3xx_node.cpp
+++ b/src/o3d3xx_node.cpp
@@ -51,6 +51,7 @@ public:
     int xmlrpc_port;
     std::string password;
     int schema_mask;
+    std::string frame_id_base;
 
     ros::NodeHandle nh("~");
     nh.param("ip", camera_ip, o3d3xx::DEFAULT_IP);
@@ -60,13 +61,12 @@ public:
     nh.param("timeout_millis", this->timeout_millis_, 500);
     nh.param("timeout_tolerance_secs", this->timeout_tolerance_secs_, 5.0);
     nh.param("publish_viz_images", this->publish_viz_images_, false);
+    nh.param("frame_id_base", frame_id_base, std::string(ros::this_node::getName()).substr(1));
 
     this->schema_mask_ = static_cast<std::uint16_t>(schema_mask);
 
-    this->frame_id_ =
-      std::string(ros::this_node::getName() + "_link").substr(1);
-    this->optical_frame_id_ =
-      std::string(ros::this_node::getName() + "_optical_link").substr(1);
+    this->frame_id_ = frame_id_base + "_link";
+    this->optical_frame_id_ = frame_id_base + "_optical_link";
 
     //-----------------------------------------
     // Instantiate the camera and frame-grabber
@@ -84,24 +84,24 @@ public:
     // Published topics
     //----------------------
     this->cloud_pub_ =
-      nh.advertise<pcl::PointCloud<o3d3xx::PointT> >("/cloud", 1);
+      nh.advertise<pcl::PointCloud<o3d3xx::PointT> >("cloud", 1);
 
     image_transport::ImageTransport it(nh);
-    this->depth_pub_ = it.advertise("/depth", 1);
-    this->depth_viz_pub_ = it.advertise("/depth_viz", 1);
-    this->amplitude_pub_ = it.advertise("/amplitude", 1);
-    this->raw_amplitude_pub_ = it.advertise("/raw_amplitude", 1);
-    this->conf_pub_ = it.advertise("/confidence", 1);
-    this->good_bad_pub_ = it.advertise("/good_bad_pixels", 1);
-    this->xyz_image_pub_ = it.advertise("/xyz_image", 1);
+    this->depth_pub_ = it.advertise("depth", 1);
+    this->depth_viz_pub_ = it.advertise("depth_viz", 1);
+    this->amplitude_pub_ = it.advertise("amplitude", 1);
+    this->raw_amplitude_pub_ = it.advertise("raw_amplitude", 1);
+    this->conf_pub_ = it.advertise("confidence", 1);
+    this->good_bad_pub_ = it.advertise("good_bad_pixels", 1);
+    this->xyz_image_pub_ = it.advertise("xyz_image", 1);
 
     // NOTE: not using ImageTransport here ... having issues with the
     // latching. I need to investigate further. A "normal" publisher seems to
     // work.
     this->uvec_pub_ =
-      nh.advertise<sensor_msgs::Image>("/unit_vectors", 1, true);
+      nh.advertise<sensor_msgs::Image>("unit_vectors", 1, true);
 
-    this->extrinsics_pub_ = nh.advertise<o3d3xx::Extrinsics>("/extrinsics", 1);
+    this->extrinsics_pub_ = nh.advertise<o3d3xx::Extrinsics>("extrinsics", 1);
 
     //----------------------
     // Advertised services
@@ -109,25 +109,25 @@ public:
     this->version_srv_ =
       nh.advertiseService<o3d3xx::GetVersion::Request,
                           o3d3xx::GetVersion::Response>
-      ("/GetVersion", std::bind(&O3D3xxNode::GetVersion, this,
+      ("GetVersion", std::bind(&O3D3xxNode::GetVersion, this,
         std::placeholders::_1,
         std::placeholders::_2));
 
     this->dump_srv_ =
       nh.advertiseService<o3d3xx::Dump::Request, o3d3xx::Dump::Response>
-      ("/Dump", std::bind(&O3D3xxNode::Dump, this,
+      ("Dump", std::bind(&O3D3xxNode::Dump, this,
                           std::placeholders::_1,
                           std::placeholders::_2));
 
     this->config_srv_ =
       nh.advertiseService<o3d3xx::Config::Request, o3d3xx::Config::Response>
-      ("/Config", std::bind(&O3D3xxNode::Config, this,
+      ("Config", std::bind(&O3D3xxNode::Config, this,
                             std::placeholders::_1,
                             std::placeholders::_2));
 
     this->rm_srv_ =
       nh.advertiseService<o3d3xx::Rm::Request, o3d3xx::Rm::Response>
-      ("/Rm", std::bind(&O3D3xxNode::Rm, this,
+      ("Rm", std::bind(&O3D3xxNode::Rm, this,
                         std::placeholders::_1,
                         std::placeholders::_2));
   }

--- a/src/o3d3xx_node.cpp
+++ b/src/o3d3xx_node.cpp
@@ -53,15 +53,16 @@ public:
     int schema_mask;
     std::string frame_id_base;
 
-    ros::NodeHandle nh("~");
-    nh.param("ip", camera_ip, o3d3xx::DEFAULT_IP);
-    nh.param("xmlrpc_port", xmlrpc_port, (int) o3d3xx::DEFAULT_XMLRPC_PORT);
-    nh.param("password", password, o3d3xx::DEFAULT_PASSWORD);
-    nh.param("schema_mask", schema_mask, (int) o3d3xx::DEFAULT_SCHEMA_MASK);
-    nh.param("timeout_millis", this->timeout_millis_, 500);
-    nh.param("timeout_tolerance_secs", this->timeout_tolerance_secs_, 5.0);
-    nh.param("publish_viz_images", this->publish_viz_images_, false);
-    nh.param("frame_id_base", frame_id_base, std::string(ros::this_node::getName()).substr(1));
+    ros::NodeHandle nh; // public
+    ros::NodeHandle np("~"); // private
+    np.param("ip", camera_ip, o3d3xx::DEFAULT_IP);
+    np.param("xmlrpc_port", xmlrpc_port, (int) o3d3xx::DEFAULT_XMLRPC_PORT);
+    np.param("password", password, o3d3xx::DEFAULT_PASSWORD);
+    np.param("schema_mask", schema_mask, (int) o3d3xx::DEFAULT_SCHEMA_MASK);
+    np.param("timeout_millis", this->timeout_millis_, 500);
+    np.param("timeout_tolerance_secs", this->timeout_tolerance_secs_, 5.0);
+    np.param("publish_viz_images", this->publish_viz_images_, false);
+    np.param("frame_id_base", frame_id_base, std::string(ros::this_node::getName()).substr(1));
 
     this->schema_mask_ = static_cast<std::uint16_t>(schema_mask);
 


### PR DESCRIPTION
…tive namespacing instead of the global namespace to allow flexibility when launching multiple cameras without defining the ns arg.  Previous defaults are conserved.

This change is recommended to facilitate multi camera setups.  For more details on why topics should be created in the relative namespace rather than the global namespace see [ROS REP 0135](http://www.ros.org/reps/rep-0135.html) and Section 5.2 Relative Names of [A Gentle Introduction to ROS](https://cse.sc.edu/~jokane/agitr/agitr-letter-names.pdf) by O’Kane.
